### PR TITLE
changes from stream review

### DIFF
--- a/build.zig.zon
+++ b/build.zig.zon
@@ -5,8 +5,7 @@
 
     .dependencies = .{
         .zli = .{
-            .url = "lib/zli",
-            .hash = "1220ff6a82ba9deb2ec4fda5a9ccc55f5dd89a7c33842050cf89da5fcac10089842c",
+            .path = "lib/zli",
         },
     },
 

--- a/src/main.zig
+++ b/src/main.zig
@@ -4,10 +4,7 @@ const zli = @import("zli");
 const exe_name = "trecker";
 const session_file_name = exe_name ++ "_session.ini";
 
-var projects: []Project = undefined;
-var entries: []Entry = undefined;
-
-pub fn main() !void {
+pub fn main() !u8 {
     var gpa = std.heap.GeneralPurposeAllocator(.{}){};
     const allocator = gpa.allocator();
     defer _ = gpa.deinit();
@@ -16,49 +13,25 @@ pub fn main() !void {
     defer args_it.deinit();
 
     const command = zli.parse(&args_it, Command);
-
-    defer {
-        for (projects) |project| {
-            project.deinit(allocator);
-        }
-        allocator.free(projects);
-        for (entries) |entry| {
-            entry.deinit(allocator);
-        }
-        allocator.free(entries);
-    }
-
-    const should_deserialize = switch (command) {
-        .init => false,
-        .start, .add, .list, .summary => true,
-    };
-    const deserialize_args: DeserializeOptions = switch (command) {
-        .init => undefined,
-        .start => .{ .extra_entry = true },
-        .add => .{ .extra_project = true },
-        .list, .summary => .{},
-    };
-
-    if (should_deserialize) {
-        deserialize(allocator, deserialize_args) catch |err| {
-            if (err == error.FileNotFound) {
-                std.debug.print("Session file was not found in the working directory. Run 'trecker init' to create a fresh one.\n", .{});
-                return;
-            }
-            return err;
-        };
-    }
-
-    try switch (command) {
-        .init => executeInitCommand(allocator),
-        .start => |args| executeStartCommand(allocator, args.positional.project_id),
-        .add => |args| executeAddCommand(allocator, args.positional.project_id, args.positional.project_name),
-        .list => executeListCommand(),
-        .summary => |args| executeSummaryCommand(allocator, args.positional.month, args.positional.year),
+    return switch (command) {
+        .init => try executeInitCommand(allocator),
+        .start => |args| try executeStartCommand(allocator, args.positional.project_id),
+        .add => |args| try executeAddCommand(
+            allocator, args.positional.project_id, args.positional.project_name
+        ),
+        .list => try executeListCommand(allocator),
+        .summary => |args| try executeSummaryCommand(
+            allocator, args.positional.month, args.positional.year
+        ),
     };
 }
 
-fn executeInitCommand(allocator: std.mem.Allocator) !void {
+fn fatal(comptime fmt: []const u8, args: anytype) noreturn {
+    std.debug.print(fmt ++ "\n", args);
+    std.process.exit(1);
+}
+
+fn executeInitCommand(allocator: std.mem.Allocator) !u8 {
     const file_exists = blk: {
         std.fs.cwd().access(session_file_name, .{}) catch |err| {
             if (err == error.FileNotFound) {
@@ -70,14 +43,22 @@ fn executeInitCommand(allocator: std.mem.Allocator) !void {
     };
 
     if (file_exists) {
-        std.debug.print("Session file already exists. Delete manually to create a new session.\n", .{});
+        std.debug.print(
+            "Session file '{s}' already exists. Delete manually to create a new session.\n",
+            .{session_file_name},
+        );
+        return 1;
     }
-    else {
-        try serialize(allocator);
-    }
+
+    const store = Store{
+        .projects = &.{},
+        .entries = &.{},
+    };
+    try store.serialize(allocator);
+    return 0;
 }
 
-fn executeSummaryCommand(allocator: std.mem.Allocator, month_str: []const u8, year_str: []const u8) !void {
+fn executeSummaryCommand(allocator: std.mem.Allocator, month_str: []const u8, year_str: []const u8) !u8 {
     const month_names: []const []const u8 = &.{
         "january",
         "february",
@@ -98,7 +79,7 @@ fn executeSummaryCommand(allocator: std.mem.Allocator, month_str: []const u8, ye
         }
     } else {
         std.debug.print("Unknown month: '{s}'\n", .{month_str});
-        return;
+        return 1;
     };
 
     const year = try std.fmt.parseInt(u16, year_str, 10);
@@ -106,7 +87,9 @@ fn executeSummaryCommand(allocator: std.mem.Allocator, month_str: []const u8, ye
     var project_hours = std.MultiArrayList(struct { p: *Project, h: f64 }){};
     defer project_hours.deinit(allocator);
 
-    for (projects) |*project| {
+    var store = try Store.deserialize(allocator, .{});
+    defer store.deinit(allocator);
+    for (store.projects) |*project| {
         try project_hours.append(allocator, .{ .p = project, .h = 0 });
     }
 
@@ -114,7 +97,7 @@ fn executeSummaryCommand(allocator: std.mem.Allocator, month_str: []const u8, ye
     var work_days: [31]Day = undefined;
     var work_days_len: usize = 0;
 
-    for (entries) |entry| {
+    for (store.entries) |entry| {
         if (entry.start.month != month) continue;
         if (entry.start.year != year) continue;
 
@@ -123,7 +106,7 @@ fn executeSummaryCommand(allocator: std.mem.Allocator, month_str: []const u8, ye
             work_days_len += 1;
         }
 
-        const project_index = for (projects, 0..) |project, i| {
+        const project_index = for (store.projects, 0..) |project, i| {
             if (std.mem.eql(u8, project.id, entry.project_id)) break i;
         } else unreachable;
 
@@ -145,50 +128,60 @@ fn executeSummaryCommand(allocator: std.mem.Allocator, month_str: []const u8, ye
     for (project_hours.items(.p), project_hours.items(.h)) |project, hours| {
         std.debug.print("{s}: {d:.2} hours ({d:.0} %)\n", .{ project.name, hours, 100.0 * hours / total_hours });
     }
+    return 0;
 }
 
-fn executeAddCommand(allocator: std.mem.Allocator, project_id: []const u8, project_name: []const u8) !void {
-    projects[projects.len - 1] = .{
+fn executeAddCommand(allocator: std.mem.Allocator, project_id: []const u8, project_name: []const u8) !u8 {
+    var store = try Store.deserialize(allocator, .{ .extra_project = true });
+    defer store.deinit(allocator);
+    store.projects[store.projects.len - 1] = .{
         .id = try allocator.dupe(u8, project_id),
         .name = try allocator.dupe(u8, project_name),
     };
-
-    try serialize(allocator);
+    try store.serialize(allocator);
+    return 0;
 }
 
-fn executeListCommand() !void {
-    std.debug.print("{d} registered projects:\n", .{projects.len});
-    for (projects) |project| {
+fn executeListCommand(allocator: std.mem.Allocator) !u8 {
+    var store = try Store.deserialize(allocator, .{});
+    defer store.deinit(allocator);
+    std.debug.print("{d} registered projects:\n", .{store.projects.len});
+    for (store.projects) |project| {
         std.debug.print("{s}: {s}\n", .{ project.id, project.name });
     }
+    return 0;
 }
 
-fn executeStartCommand(allocator: std.mem.Allocator, project_id: []const u8) !void {
-    const project = findProject(project_id) orelse {
+fn executeStartCommand(allocator: std.mem.Allocator, project_id: []const u8) !u8 {
+
+    var store = try Store.deserialize(allocator, .{ .extra_entry = true });
+    defer store.deinit(allocator);
+
+    const project = store.findProject(project_id) orelse {
         std.debug.print("Project with given ID not found: {s}\n", .{project_id});
         std.debug.print("Known IDs:", .{});
-        for (projects) |project| {
+        for (store.projects) |project| {
             std.debug.print(" {s}", .{project.id});
         }
         std.debug.print("\n", .{});
-        return;
+        return 1;
     };
 
-    var entry = &entries[entries.len - 1];
+    var last_entry = &store.entries[store.entries.len - 1];
 
     const raw_start = std.time.timestamp();
     var raw_end = std.time.timestamp();
-    entry.* = Entry{
+    last_entry.* = Entry{
         .project_id = project.id,
         .start = Timestamp.now(),
         .end = Timestamp.now(),
     };
 
     var initial_total_today: i64 = 0;
-    for (entries) |other| {
-        if (entry.start.year != other.start.year) continue;
-        if (entry.start.month != other.start.month) continue;
-        if (entry.start.day != other.start.day) continue;
+    for (store.entries) |other| {
+        if (last_entry.start.year != other.start.year) continue;
+        if (last_entry.start.month != other.start.month) continue;
+        if (last_entry.start.day != other.start.day) continue;
         initial_total_today += other.getTotalSeconds();
     }
 
@@ -204,86 +197,129 @@ fn executeStartCommand(allocator: std.mem.Allocator, project_id: []const u8) !vo
         const entry_minutes = getMinutes(raw_end - raw_start);
         if (entry_minutes != minutes) {
             raw_end = raw_now;
-            entry.end = Timestamp.now();
-            try serialize(allocator);
+            last_entry.end = Timestamp.now();
+            try store.serialize(allocator);
         }
 
         const one_second = 1_000_000_000;
         std.time.sleep(one_second);
     }
+    return 0;
 }
 
-fn serialize(allocator: std.mem.Allocator) !void {
-    var text = std.ArrayList(u8).init(allocator);
-    defer text.deinit();
-
-    try text.writer().print("version: 1\n", .{});
-
-    try text.writer().print("\n", .{});
-    for (projects) |project| {
-        try text.writer().print("project: {s} '{s}'\n", .{ project.id, project.name });
-    }
-
-    try text.writer().print("\n", .{});
-    for (entries) |entry| {
-        try text.writer().print("entry: {s} {s}..{s}\n", .{ entry.project_id, entry.start.toString(), entry.end.toString() });
-    }
-
-    try std.fs.cwd().writeFile(.{ .sub_path = session_file_name, .data = text.items });
-}
-
-const DeserializeOptions = struct { extra_project: bool = false, extra_entry: bool = false };
-fn deserialize(allocator: std.mem.Allocator, options: DeserializeOptions) !void {
-    const text = try std.fs.cwd().readFileAlloc(allocator, session_file_name, 1024 * 1024 * 1024);
-    defer allocator.free(text);
-
-    var projects_list = std.ArrayList(Project).init(allocator);
-    defer projects_list.deinit();
-    var entries_list = std.ArrayList(Entry).init(allocator);
-    defer entries_list.deinit();
-
-    var lines_it = std.mem.split(u8, text, "\n");
-    const version_line = lines_it.next().?;
-    const version = getTrimmedValue(version_line, "version");
-    if (version == null or !std.mem.eql(u8, version.?, "1")) return error.UnsupportedVersion;
-
-    while (lines_it.next()) |line| {
-        if (getTrimmedValue(line, "project")) |project_str| {
-            var space_split = std.mem.split(u8, project_str, " ");
-            const id = space_split.next().?;
-            const rest = project_str[id.len + 1 ..];
-            const name = std.mem.trim(u8, rest, "'");
-            try projects_list.append(.{
-                .id = try allocator.dupe(u8, id),
-                .name = try allocator.dupe(u8, name),
-            });
-        } else if (getTrimmedValue(line, "entry")) |entry_str| {
-            var space_split = std.mem.split(u8, entry_str, " ");
-            const project_id = space_split.next().?;
-            const rest = entry_str[project_id.len + 1 ..];
-            var range_it = std.mem.split(u8, rest, "..");
-            const start_str = range_it.next().?;
-            const end_str = range_it.next().?;
-            try entries_list.append(.{
-                .project_id = try allocator.dupe(u8, project_id),
-                .start = try Timestamp.fromString(start_str),
-                .end = try Timestamp.fromString(end_str),
-            });
+const Store = struct {
+    projects: []Project,
+    entries: []Entry,
+    pub fn deinit(self: *Store, allocator: std.mem.Allocator) void {
+        for (self.projects) |project| {
+            project.deinit(allocator);
         }
+        allocator.free(self.projects);
+        for (self.entries) |entry| {
+            entry.deinit(allocator);
+        }
+        allocator.free(self.entries);
+        self.* = undefined;
     }
 
-    if (options.extra_project) {
-        try projects_list.append(undefined);
+    const DeserializeOptions = struct {
+        extra_project: bool = false,
+        extra_entry: bool = false,
+    };
+    fn deserialize(allocator: std.mem.Allocator, options: DeserializeOptions) !Store {
+        const text = std.fs.cwd().readFileAlloc(
+            allocator, session_file_name, 1024 * 1024 * 1024
+        ) catch |err| switch (err) {
+            error.FileNotFound => fatal(
+                "Session file {s} was not found in the working directory. Run 'trecker init' to create a fresh one.",
+                .{session_file_name},
+            ),
+            else => |e| return e,
+        };
+        defer allocator.free(text);
+        return parse(allocator, options, text) catch |err| fatal(
+            "{s}: parse error: {s}", .{session_file_name, @errorName(err)},
+        );
     }
-    if (options.extra_entry) {
-        try entries_list.append(undefined);
+    fn parse(allocator: std.mem.Allocator, options: DeserializeOptions, text: []const u8) !Store {
+        var projects: std.ArrayListUnmanaged(Project) = .{};
+        defer projects.deinit(allocator);
+        var entries: std.ArrayListUnmanaged(Entry) = .{};
+        defer entries.deinit(allocator);
+
+        var lines_it = std.mem.split(u8, text, "\n");
+        const version_line = lines_it.first();
+        const version = getTrimmedValue(version_line, "version");
+        if (version == null) return error.MissingVersion;
+        if (!std.mem.eql(u8, version.?, "1")) return error.UnsupportedVersion;
+
+        while (lines_it.next()) |line| {
+            if (getTrimmedValue(line, "project")) |project_str| {
+                var space_split = std.mem.split(u8, project_str, " ");
+                const id = space_split.first();
+                const rest = project_str[id.len + 1 ..];
+                const name = std.mem.trim(u8, rest, "'");
+                try projects.append(allocator, .{
+                    .id = try allocator.dupe(u8, id),
+                    .name = try allocator.dupe(u8, name),
+                });
+            } else if (getTrimmedValue(line, "entry")) |entry_str| {
+                var space_split = std.mem.split(u8, entry_str, " ");
+                const project_id = space_split.first();
+                const rest = entry_str[project_id.len + 1 ..];
+                var range_it = std.mem.split(u8, rest, "..");
+                const start_str = range_it.next().?;
+                const end_str = range_it.next().?;
+                try entries.append(allocator, .{
+                    .project_id = try allocator.dupe(u8, project_id),
+                    .start = try Timestamp.fromString(start_str),
+                    .end = try Timestamp.fromString(end_str),
+                });
+            }
+        }
+
+        if (options.extra_project) {
+            try projects.append(allocator, undefined);
+        }
+        if (options.extra_entry) {
+            try entries.append(allocator, undefined);
+        }
+
+        return .{
+            .projects = try projects.toOwnedSlice(allocator),
+            .entries = try entries.toOwnedSlice(allocator),
+        };
     }
 
-    projects = try allocator.dupe(Project, projects_list.items);
-    entries = try allocator.dupe(Entry, entries_list.items);
+    fn findProject(self: Store, id: []const u8) ?*Project {
+        for (self.projects) |*project| {
+            if (std.mem.eql(u8, id, project.id)) {
+                return project;
+            }
+        }
+        return null;
+    }
 
-    return;
-}
+    fn serialize(self: Store, allocator: std.mem.Allocator) !void {
+        var text = std.ArrayList(u8).init(allocator);
+        defer text.deinit();
+
+        try text.writer().print("version: 1\n", .{});
+
+        try text.writer().print("\n", .{});
+        for (self.projects) |project| {
+            try text.writer().print("project: {s} '{s}'\n", .{ project.id, project.name });
+        }
+
+        try text.writer().print("\n", .{});
+        for (self.entries) |entry| {
+            try text.writer().print("entry: {s} {s}..{s}\n", .{ entry.project_id, entry.start.toString(), entry.end.toString() });
+        }
+
+        try std.fs.cwd().writeFile(.{ .sub_path = session_file_name, .data = text.items });
+    }
+
+};
 
 fn getTrimmedValue(line: []const u8, comptime name: []const u8) ?[]const u8 {
     const prefix = name ++ ": ";
@@ -304,15 +340,6 @@ fn getMinutes(total_seconds: i64) u64 {
 
 fn getHours(total_seconds: i64) u64 {
     return @intCast(@divFloor(total_seconds, 60 * 60));
-}
-
-fn findProject(id: []const u8) ?*Project {
-    for (projects) |*project| {
-        if (std.mem.eql(u8, id, project.id)) {
-            return project;
-        }
-    }
-    return null;
 }
 
 const Project = struct {


### PR DESCRIPTION
* fixed build.zig.zon to use ".path" instead of ".url"
* replaced global variables with locals - this revealed a few uses of uninitalized memory that have been fixed
* ensured non-zero exit codes for operations that fail
* leveraged the "first()" function on split iterator instead of "next().?"